### PR TITLE
UNRW-482: Automate Syria Refugee count on Crisis Overview.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -17,7 +17,7 @@
   "environment": {
     "baseUrl": "http://crisis.rwlabs.org/syria/",
     "sources": {
-      "hdx": "http://data.hdx.rwlabs.org/api",
+      "hdx": "https://data.hdx.rwlabs.org/api",
       "fts": "http://fts.unocha.org/api",
       "reliefweb": "http://api.rwlabs.org",
       "reliefweb-embed": "http://embed.rwdev.org"
@@ -28,7 +28,7 @@
       "slug": "crisis-overview",
       "title": "Crisis Overview",
       "config": {
-        "url": "https://gist.githubusercontent.com/fillerwriter/7fd144c2f4160c3c8004/raw/crisis-overview.json"
+        "url": "https://gist.githubusercontent.com/grayside/6ffb57b9979575f013c2/raw/crisis-overview.json"
       }
     },
     {


### PR DESCRIPTION
Configuration changes to use the collector script to get the Syria Registered Refugees from HDX.

``` js
        {
          "figure": {
            "type": "request",
            "source": "hdx",
            "path": "action/datastore_search_sql?sql=SELECT%20value,updated_at,_id%20FROM%20%22b8b5670f-ce85-4c50-bb30-aa6003e29f2e%22%20WHERE%20%22module_name%22%20like%20%27Registered%20Syrian%20Refugees%27%20ORDER%20BY%2$
            "selector": "$.result.records[0]",
            "fallback": -1,
            "content": [
              {
                "_id": 836,
                "updated_at": "2015-03-18T00:00:00",
                "value": 3922166
              }
            ],
            "date": {
              "checked": "2015-03-19T18:24:41.620Z",
              "updated": "2015-03-19T18:24:41.620Z"
            }
          },
          "description": "Refugees"
        },
```
