### PR TITLE
Add --local option to collector to skip download of remote config.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,6 +96,9 @@ module.exports = function (grunt) {
     shell: {
       collect: {
         command: 'bin/collect | node_modules/.bin/bunyan'
+      },
+      'collect-local': {
+        command: 'bin/collect --local | node_modules/.bin/bunyan'
       }
     },
     clean: {

--- a/collector/lib/collect.js
+++ b/collector/lib/collect.js
@@ -67,7 +67,9 @@ module.exports = function(config, opts) {
 
   // Pull any remote referenced widget configuration files.
   module.saveRemoteConfig = function() {
-    var collectRemoteConfig = async.seq(downloadRemoteConfig, signConfig, inlineRequestData, insertEnvironment, saveConfig);
+    var loadConfig = opts.local ? loadLocalConfig : downloadRemoteConfig;
+
+    var collectRemoteConfig = async.seq(loadConfig, signConfig, inlineRequestData, insertEnvironment, saveConfig);
 
     config.widgets.map(function(widget) {
       // If there is not a URL, assume there is no remote configuration.
@@ -107,6 +109,11 @@ module.exports = function(config, opts) {
       return widget;
     });
   };
+
+  function loadLocalConfig(item, callback) {
+    item.content = require(path.join('../../config/config', item.name));
+    callback(null, item);
+  }
 
   function downloadRemoteConfig(item, callback) {
     var request = agent.get(item.url).end(function(err, response) {

--- a/collector/lib/index.js
+++ b/collector/lib/index.js
@@ -13,6 +13,10 @@ var opts = require('nomnom')
     flag: true,
     help: 'In dev mode the configuration is pulled and written to src/ instead of dev/.'
   })
+  .option('local', {
+    flag: true,
+    help: 'Do not download remote files, use existing local files inside config/ directory.'
+  })
   .option('widget-config-path', {
     help: 'Specify the directory path within the docroot where widget config should be saved. [Variation Untested].',
     default: 'config'


### PR DESCRIPTION
When needing to rapidly iterate on a widget configuration it can be a pain to update a gist and re-download. Amongst other things it a dependency on github we don't need for active development.

This change adds a `--local` option that will load `config/config/widget.json` from disk and then apply the rest of the normal processing. You can use it with `grunt collector-local` if you like.
