### PR TITLE
UNRW-473: Add UA code snippet if Google Analytics key is specified.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -34,6 +34,9 @@
       "fts": "http://fts.unocha.org/api",
       "reliefweb": "http://api.rwlabs.org",
       "reliefweb-embed": "http://embed.rwdev.org"
+    },
+    "keys": {
+      "google-analytics": "UA-61363709-1"
     }
   },
   "widgets": [

--- a/src/templates/index.handlebars
+++ b/src/templates/index.handlebars
@@ -105,6 +105,19 @@
 <!-- Typekit -->
 <script src="//use.typekit.net/hny7ecg.js"></script>
 <script>try{Typekit.load();}catch(e){}</script>
+
+{{#if environment.keys.google-analytics}}
+<!-- Google Analytics -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{environment.keys.google-analytics}}', 'auto');
+  ga('send', 'pageview');
+</script>
+{{/if}}
 </body>
 
 </html>


### PR DESCRIPTION
Adds a new "keys" section to the configuration with a test GA account pre-configured.

If the Google Analytics key is not specified the code snippet is not injected into the page.
