### PR TITLE
UNRW-522: Remove trailing slashes from URLs.

### DIFF
--- a/env/prod/etc/nginx/conf.d/localhost.conf
+++ b/env/prod/etc/nginx/conf.d/localhost.conf
@@ -43,6 +43,11 @@ server {
     deny  all;
   }
 
+  # Redirect /foo/ and /foo/index.html to /foo
+  # http://serverfault.com/a/597848
+  rewrite ^(.+)/+$ $1 permanent;
+  rewrite ^(.+)/index.html$ $1 permanent;
+
   gzip on;
   gzip_buffers 16 8k;
   gzip_comp_level 6;

--- a/env/stage/etc/nginx/conf.d/localhost.conf
+++ b/env/stage/etc/nginx/conf.d/localhost.conf
@@ -43,6 +43,11 @@ server {
     deny  all;
   }
 
+  # Redirect /foo/ and /foo/index.html to /foo
+  # http://serverfault.com/a/597848
+  rewrite ^(.+)/+$ $1 permanent;
+  rewrite ^(.+)/index.html$ $1 permanent;
+
   gzip on;
   gzip_buffers 16 8k;
   gzip_comp_level 6;


### PR DESCRIPTION
foo/ => foo
foo/index.html => foo
